### PR TITLE
Changing name for force calculations

### DIFF
--- a/doc/source/paraview/distributionForce.rst
+++ b/doc/source/paraview/distributionForce.rst
@@ -7,8 +7,8 @@ Computing these distributions is done through ParaView by importing the case, sl
 
 .. note::
 
-   This utility expects a variable called ``force`` that is the force divided by area on each surface cell face.
-   For the utility to work, this ``force`` variable must exist for the surfaces included in the force computation.
+   This utility expects a variable called ``forcePerS`` that is the force divided by area on each surface cell face.
+   For the utility to work, this ``forcePerS`` variable must exist for the surfaces included in the force computation.
 
 The force of a particular slice is computed by projecting the force on each cell face in the direction specified by the user.
 The forces are then integrated over the slice to compute the total force.

--- a/postprocessing/paraview/distributions.py
+++ b/postprocessing/paraview/distributions.py
@@ -178,7 +178,7 @@ def generate_force_distribution(
         registrationName="paraview.foam", FileName=str(os.getcwd()) + "/{}".format(input_file)
     )
     paraviewfoam.MeshRegions = patches
-    paraviewfoam.CellArrays = ["force"]
+    paraviewfoam.CellArrays = ["forcePerS"]
 
     # Read time data
     animationScene1 = paraview.GetAnimationScene()
@@ -206,7 +206,7 @@ def generate_force_distribution(
             # Set calculator
             calculator1 = paraview.Calculator(registrationName="Calculator", Input=slice1)
             calculator1.ResultArrayName = "force_dot_dir"
-            calculator1.Function = "dot(force,{}*iHat + {}*jHat + {}*kHat)".format(
+            calculator1.Function = "dot(forcePerS,{}*iHat + {}*jHat + {}*kHat)".format(
                 force_direction[0], force_direction[1], force_direction[2]
             )
 

--- a/postprocessing/paraview/slices.py
+++ b/postprocessing/paraview/slices.py
@@ -146,7 +146,7 @@ def generate_slices_cp(
         Name pattern to write out files in the output directory. Default is
         "slice".
     patches : str or list
-        Patch name(s) over which to compute the force distribution. Default
+        Patch name(s) over which to compute the slice(s). Default
         is "group/wall".
     span_direction : str or list
         Vector direction for span direction either as a string (eg. X) or list


### PR DESCRIPTION
The force calculations previously relied on a variable called `force`, but the actual values are a force / area. Changing the name to `forcePerS` instead to be more accurate.