### PR TITLE
Scripting Font Installation

### DIFF
--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Install Font(s)
       run: |
-        ../../scripts/install_fonts.sh
+        ./scripts/install_fonts.sh
 
     - name: Download Input Data
       run: |

--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -24,15 +24,7 @@ jobs:
 
     - name: Install Font(s)
       run: |
-        fonts="https://font.download/dl/font/cmu-bright.zip"
-        for font in $fonts; do
-          curl -L -o font.zip $font
-          unzip font.zip -d font
-          mkdir -p ~/.local/share/fonts
-          mv font/*.ttf ~/.local/share/fonts/
-          rm -r font/ font.zip
-        done
-        fc-cache -f -v ~/.local/share/fonts
+        ../../scripts/install_fonts.sh
 
     - name: Download Input Data
       run: |

--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -10,3 +10,6 @@ python:
       
 sphinx:
   configuration: doc/conf.py
+
+commands:
+  - bash ../scripts/install_fonts.sh

--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -1,8 +1,13 @@
 version: 2
+
 build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
+  jobs:
+    pre_install:
+      - bash ../scripts/install_fonts.sh
+
 python:
   install:
     - method: pip
@@ -10,6 +15,3 @@ python:
       
 sphinx:
   configuration: doc/conf.py
-
-commands:
-  - bash ../scripts/install_fonts.sh

--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -6,7 +6,7 @@ build:
     python: "3.12"
   jobs:
     pre_install:
-      - bash ../scripts/install_fonts.sh
+      - bash ./scripts/install_fonts.sh
 
 python:
   install:

--- a/scripts/install_fonts.sh
+++ b/scripts/install_fonts.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+fonts="https://font.download/dl/font/cmu-bright.zip"
+
+# Function to install fonts on Linux
+install_fonts_linux() {
+    echo "Installing fonts on Linux..."
+    mkdir -p ~/.local/share/fonts
+    mv font/*.ttf ~/.local/share/fonts/
+    fc-cache -f -v ~/.local/share/fonts
+}
+
+# Function to install fonts on macOS
+install_fonts_macos() {
+    echo "Installing fonts on macOS..."
+    mkdir -p ~/Library/Fonts
+    mv font/*.ttf ~/Library/Fonts/
+}
+
+# Download and unzip the font
+download_and_extract_fonts() {
+    for font in $fonts; do
+        curl -L -o font.zip $font
+        unzip font.zip -d font
+        rm font.zip
+    done
+}
+
+# Detect the operating system
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    download_and_extract_fonts
+    install_fonts_linux
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    download_and_extract_fonts
+    install_fonts_macos
+else
+    echo "Unsupported OS: $OSTYPE"
+    exit 1
+fi
+
+# Clean up
+rm -rf font


### PR DESCRIPTION
## Purpose

Installing fonts for each plotting profile is important to ensuring the output figures are correct. I am adding a script that can be called by a user, GitHub actions, or ReadTheDocs (and others) to streamline this process.

Currently, the figures and printouts on ReadTheDocs are wrong because they do not have the correct font.

## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [X] Maintenance update
- [ ] Other (please describe)

## Testing

Tested locally on Mac -- will allow GitHub Actions and ReadTheDocs to test this automatically.

## Checklist

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have run the tests and they pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
