### PR TITLE
Fixing ReadTheDocs Font Install

### DIFF
--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -6,12 +6,20 @@ build:
     python: "3.12"
   jobs:
     pre_install:
+      - |
+        if ! command -v sudo &>/dev/null; then
+          echo "sudo is not installed. Installing sudo..."
+          apt-get update
+          apt-get install -y sudo
+        else
+          echo "sudo is already installed."
+        fi
       - bash ./scripts/install_fonts.sh
 
 python:
   install:
     - method: pip
       path: .[doc]
-      
+
 sphinx:
   configuration: doc/conf.py

--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -6,14 +6,6 @@ build:
     python: "3.12"
   jobs:
     pre_install:
-      - |
-        if ! command -v sudo &>/dev/null; then
-          echo "sudo is not installed. Installing sudo..."
-          apt-get update
-          apt-get install -y sudo
-        else
-          echo "sudo is already installed."
-        fi
       - bash ./scripts/install_fonts.sh
 
 python:

--- a/scripts/install_fonts.sh
+++ b/scripts/install_fonts.sh
@@ -9,7 +9,7 @@ install_fonts_linux() {
         font_name=$(basename "$font" .zip)
         mkdir -p "$HOME/.local/share/fonts/$font_name"
         mv "font/$font_name/"*.ttf "$HOME/.local/share/fonts/$font_name/"
-        ln -s "$HOME/.local/share/fonts/$font_name" "/usr/share/fonts/truetype/$font_name"
+        sudo ln -s "$HOME/.local/share/fonts/$font_name" "/usr/share/fonts/truetype/$font_name"
     done
     fc-cache -f -v
 }

--- a/scripts/install_fonts.sh
+++ b/scripts/install_fonts.sh
@@ -9,7 +9,7 @@ install_fonts_linux() {
         font_name=$(basename "$font" .zip)
         mkdir -p "$HOME/.local/share/fonts/$font_name"
         mv "font/$font_name/"*.ttf "$HOME/.local/share/fonts/$font_name/"
-        sudo ln -s "$HOME/.local/share/fonts/$font_name" "/usr/share/fonts/truetype/$font_name"
+        ln -s "$HOME/.local/share/fonts/$font_name" "/usr/share/fonts/truetype/$font_name"
     done
     fc-cache -f -v
 }


### PR DESCRIPTION
## Purpose

The examples generated in RTD use the wrong font because the font installation fails due to `sudo not recognized`. Fixing that in this PR.

## Type of change

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [X] Maintenance update
- [ ] Other (please describe)

## Testing

N / A

## Checklist

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have run the tests and they pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
